### PR TITLE
Update SpaceSuitCapabilityProvider.java

### DIFF
--- a/src/main/java/net/mrscauthd/boss_tools/capability/SpaceSuitCapabilityProvider.java
+++ b/src/main/java/net/mrscauthd/boss_tools/capability/SpaceSuitCapabilityProvider.java
@@ -38,7 +38,7 @@ public class SpaceSuitCapabilityProvider implements ICapabilityProvider, IOxygen
 			return LazyOptional.of(this::getOxygenStorage).cast();
 		}
 
-		return null;
+		return LazyOptional.empty();
 	}
 
 	@Override


### PR DESCRIPTION
Fix crash on SpaceSuitCapabilityProvider when installed CoFH-Core

java.lang.RuntimeException: Provider net.mrscauthd.boss_tools.capability.SpaceSuitCapabilityProvider.getCapability() returned null; return LazyOptional.empty() instead!
	at net.minecraftforge.common.capabilities.CapabilityDispatcher.getCapability(CapabilityDispatcher.java:107) ~[?:?] {re:classloading}
	at net.minecraftforge.common.capabilities.CapabilityProvider.getCapability(CapabilityProvider.java:118) ~[?:?] {re:classloading,re:mixin}
	at net.minecraftforge.common.capabilities.ICapabilityProvider.getCapability(ICapabilityProvider.java:48) ~[?:?] {re:classloading,re:mixin}
	at cofh.lib.util.helpers.AreaEffectHelper.validAreaEffectItem(AreaEffectHelper.java:36) ~[?:1.3.1] {re:classloading}
	at cofh.core.event.AreaEffectClientEvents.renderBlockHighlights(AreaEffectClientEvents.java:52) ~[?:1.3.1] {re:classloading}
	at net.minecraftforge.eventbus.ASMEventHandler_127_AreaEffectClientEvents_renderBlockHighlights_HighlightBlock.invoke(.dynamic) ~[?:?] {}
	at net.minecraftforge.eventbus.ASMEventHandler.invoke(ASMEventHandler.java:85) ~[eventbus-4.0.0.jar:?] {}
	at net.minecraftforge.eventbus.EventBus$$Lambda$2577/62822923.invoke(Unknown Source) ~[?:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:302) ~[eventbus-4.0.0.jar:?] {}
	at net.minecraftforge.eventbus.EventBus.post(EventBus.java:283) ~[eventbus-4.0.0.jar:?] {}
	at net.minecraftforge.client.ForgeHooksClient.onDrawBlockHighlight(ForgeHooksClient.java:146) ~[?:?] {re:classloading,re:mixin}
	at net.minecraft.client.renderer.WorldRenderer.func_228426_a_(WorldRenderer.java:1101) ~[?:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.client.renderer.GameRenderer.func_228378_a_(GameRenderer.java:608) ~[?:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.client.renderer.GameRenderer.func_195458_a(GameRenderer.java:425) ~[?:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.client.Minecraft.func_195542_b(Minecraft.java:976) [?:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:607) [?:?] {re:classloading,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A}
	at net.minecraft.client.main.Main.main(Main.java:184) [?:?] {re:classloading,pl:runtimedistcleaner:A}
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_51] {}
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_51] {}
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_51] {}
	at java.lang.reflect.Method.invoke(Method.java:497) ~[?:1.8.0_51] {}
	at net.minecraftforge.fml.loading.FMLClientLaunchProvider.lambda$launchService$0(FMLClientLaunchProvider.java:51) [forge-1.16.5-36.2.0.jar:36.2] {}
	at net.minecraftforge.fml.loading.FMLClientLaunchProvider$$Lambda$450/439720255.call(Unknown Source) [forge-1.16.5-36.2.0.jar:36.2] {}
	at cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:37) [modlauncher-8.0.9.jar:?] {}
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:54) [modlauncher-8.0.9.jar:?] {}
	at cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:72) [modlauncher-8.0.9.jar:?] {}
	at cpw.mods.modlauncher.Launcher.run(Launcher.java:82) [modlauncher-8.0.9.jar:?] {}
	at cpw.mods.modlauncher.Launcher.main(Launcher.java:66) [modlauncher-8.0.9.jar:?] {}
