### PR TITLE
some fix in NASA Workbench gui

### DIFF
--- a/src/main/java/net/mrscauthd/boss_tools/gui/ContainerHelper.java
+++ b/src/main/java/net/mrscauthd/boss_tools/gui/ContainerHelper.java
@@ -29,20 +29,20 @@ public class ContainerHelper {
 		}
 	}
 
-	public static ItemStack transferStackInSlot(Container container, PlayerEntity player, int index, IInventory tileEntity, IMergeItemStack mergeItemStack) {
+	public static ItemStack transferStackInSlot(Container container, PlayerEntity player, int slotNumber, int inventoryIndex, IInventory inventory, IMergeItemStack mergeItemStack) {
 		ItemStack itemStack = ItemStack.EMPTY;
 		List<Slot> inventorySlots = container.inventorySlots;
-		Slot slot = inventorySlots.get(index);
+		Slot slot = inventorySlots.get(slotNumber);
 
 		if (slot != null && slot.getHasStack()) {
 			ItemStack slotStack = slot.getStack();
 			itemStack = slotStack.copy();
 
-			if (index < tileEntity.getSizeInventory()) {
-				if (!mergeItemStack.mergeItemStack(slotStack, tileEntity.getSizeInventory(), inventorySlots.size(), true)) {
+			if (inventoryIndex < inventory.getSizeInventory()) {
+				if (!mergeItemStack.mergeItemStack(slotStack, inventory.getSizeInventory(), inventorySlots.size(), true)) {
 					return ItemStack.EMPTY;
 				}
-			} else if (!mergeItemStack.mergeItemStack(slotStack, 0, tileEntity.getSizeInventory(), false)) {
+			} else if (!mergeItemStack.mergeItemStack(slotStack, 0, inventory.getSizeInventory(), false)) {
 				return ItemStack.EMPTY;
 			}
 
@@ -54,6 +54,10 @@ public class ContainerHelper {
 		}
 
 		return itemStack;
+	}
+
+	public static ItemStack transferStackInSlot(Container container, PlayerEntity player, int slotNumber, IInventory inventory, IMergeItemStack mergeItemStack) {
+		return transferStackInSlot(container, player, slotNumber, slotNumber, inventory, mergeItemStack);
 	}
 
 }

--- a/src/main/java/net/mrscauthd/boss_tools/machines/WorkbenchBlock.java
+++ b/src/main/java/net/mrscauthd/boss_tools/machines/WorkbenchBlock.java
@@ -320,11 +320,6 @@ public class WorkbenchBlock extends BossToolsModElements.ModElement {
 		}
 
 		@Override
-		public int getInventoryStackLimit() {
-			return 1;
-		}
-
-		@Override
 		public void setInventorySlotContents(int p_70299_1_, ItemStack p_70299_2_) {
 			super.setInventorySlotContents(p_70299_1_, p_70299_2_);
 			this.cacheRecipes();


### PR DESCRIPTION
1. Fix sort through 'Inventory Tweaks'
-> In testing, i saw some item removed when sort
-> change NASA Workbench gui's stack limit to 64

1. FIx itemstack transfer (Shift+Click item)
-> rocket part transfer to other part slot (to inventory normally)
-> remain bugs, after rework NSASA Workbench crafting to manual