### PR TITLE
Add again Mekanism compat (unidirectional)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,12 @@ dependencies {
   
   //Hwyla
   compile fg.deobf("curse.maven:hwyla-253449:3033593")
+  
+  //Mekanism
+  compile fg.deobf("mekanism:Mekanism:1.16.5-10.0.20.447")
+  runtimeOnly fg.deobf("mekanism:Mekanism:1.16.5-10.0.20.447:additions")
+  runtimeOnly fg.deobf("mekanism:Mekanism:1.16.5-10.0.20.447:generators")
+  runtimeOnly fg.deobf("mekanism:Mekanism:1.16.5-10.0.20.447:tools")
 }
 
 mixin {

--- a/src/main/java/net/mrscauthd/boss_tools/capability/OxygenUtil.java
+++ b/src/main/java/net/mrscauthd/boss_tools/capability/OxygenUtil.java
@@ -2,6 +2,8 @@ package net.mrscauthd.boss_tools.capability;
 
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.IItemHandlerModifiable;
+import net.mrscauthd.boss_tools.compat.CompatibleManager;
+import net.mrscauthd.boss_tools.compat.mekanism.MekanismHelper;
 
 public class OxygenUtil {
 
@@ -10,6 +12,14 @@ public class OxygenUtil {
 
 		if (oxygenStorage != null) {
 			return oxygenStorage;
+		}
+		
+		if (CompatibleManager.MEKANISM.isLoaded()) {
+			IOxygenStorage adapter = MekanismHelper.getItemStackOxygenAdapter(itemStack);
+
+			if (adapter != null) {
+				return adapter;
+			}
 		}
 
 		return null;

--- a/src/main/java/net/mrscauthd/boss_tools/capability/SpaceSuitCapabilityProvider.java
+++ b/src/main/java/net/mrscauthd/boss_tools/capability/SpaceSuitCapabilityProvider.java
@@ -6,6 +6,9 @@ import net.minecraft.util.Direction;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.LazyOptional;
+import net.mrscauthd.boss_tools.compat.CompatibleManager;
+import net.mrscauthd.boss_tools.compat.mekanism.MekanismHelper;
+import net.mrscauthd.boss_tools.compat.mekanism.OxygenStorageGasAdapter;
 
 public class SpaceSuitCapabilityProvider implements ICapabilityProvider, IOxygenStorageHolder {
 
@@ -36,6 +39,12 @@ public class SpaceSuitCapabilityProvider implements ICapabilityProvider, IOxygen
 		if (capability == CapabilityOxygen.OXYGEN) {
 			this.readOxygen();
 			return LazyOptional.of(this::getOxygenStorage).cast();
+		}
+
+		if (CompatibleManager.MEKANISM.isLoaded()) {
+			if (capability == MekanismHelper.getGasHandlerCapability()) {
+				return LazyOptional.of(() -> new OxygenStorageGasAdapter(this.getCapability(CapabilityOxygen.OXYGEN, direction).orElse(null), false, true)).cast();
+			}
 		}
 
 		return LazyOptional.empty();

--- a/src/main/java/net/mrscauthd/boss_tools/compat/CompatibleManager.java
+++ b/src/main/java/net/mrscauthd/boss_tools/compat/CompatibleManager.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 
 import net.mrscauthd.boss_tools.compat.hwyla.HwylaCompat;
+import net.mrscauthd.boss_tools.compat.mekanism.MekanismCompat;
 import net.mrscauthd.boss_tools.compat.theoneprobe.TOPCompat;
 import net.mrscauthd.boss_tools.compat.tinkers.TinkersCompat;
 
@@ -14,12 +15,14 @@ public class CompatibleManager {
 	public static final TinkersCompat TINKERS;
 	public static final TOPCompat TOP;
 	public static final HwylaCompat HWYLA;
+	public static final MekanismCompat MEKANISM;
 
 	static {
 		List<CompatibleMod> mods = new ArrayList<>();
 		mods.add(TINKERS = new TinkersCompat());
 		mods.add(TOP = new TOPCompat());
 		mods.add(HWYLA = new HwylaCompat());
+		mods.add(MEKANISM = new MekanismCompat());
 
 		MODS = Collections.unmodifiableList(mods);
 	}

--- a/src/main/java/net/mrscauthd/boss_tools/compat/mekanism/GasHandlerOxygenAdapter.java
+++ b/src/main/java/net/mrscauthd/boss_tools/compat/mekanism/GasHandlerOxygenAdapter.java
@@ -1,0 +1,120 @@
+package net.mrscauthd.boss_tools.compat.mekanism;
+
+import mekanism.api.Action;
+import mekanism.api.chemical.gas.Gas;
+import mekanism.api.chemical.gas.GasStack;
+import mekanism.api.chemical.gas.IGasHandler;
+import mekanism.common.registries.MekanismGases;
+import net.mrscauthd.boss_tools.capability.IOxygenStorage;
+
+public class GasHandlerOxygenAdapter implements IOxygenStorage {
+
+	private IGasHandler gasHandler;
+	private boolean canExtract;
+	private boolean canReceive;
+
+	public GasHandlerOxygenAdapter(IGasHandler gasHandler) {
+		this(gasHandler, true, true);
+	}
+
+	public GasHandlerOxygenAdapter(IGasHandler gasHandler, boolean canExtract, boolean canReceive) {
+		this.gasHandler = gasHandler;
+		this.canExtract = canExtract;
+		this.canReceive = canReceive;
+	}
+
+	public Gas getGas() {
+		return MekanismGases.OXYGEN.get();
+	}
+
+	protected GasStack createGasStack(int amount) {
+		return new GasStack(this.getGas(), amount);
+	}
+
+	@Override
+	public int receiveOxygen(int maxReceive, boolean simulate) {
+		if (!this.isCanReceive()) {
+			return 0;
+		}
+
+		GasStack toInsert = this.createGasStack(maxReceive);
+		GasStack remain = this.getGasHandler().insertChemical(toInsert, Action.get(!simulate));
+
+		if (remain.isEmpty()) {
+			return maxReceive;
+		} else {
+			return (int) (maxReceive - remain.getAmount());
+		}
+
+	}
+
+	@Override
+	public int extractOxygen(int maxExtract, boolean simulate) {
+		if (!this.isCanExtract()) {
+			return 0;
+		}
+
+		return (int) this.getGasHandler().extractChemical(maxExtract, Action.get(!simulate)).getAmount();
+	}
+
+	@Override
+	public int getOxygenStored() {
+		long stored = 0;
+		IGasHandler gasHandler = this.getGasHandler();
+		int tanks = gasHandler.getTanks();
+
+		for (int i = 0; i < tanks; i++) {
+			GasStack stack = gasHandler.getChemicalInTank(i);
+
+			if (stack.getType() == this.getGas()) {
+				stored = Math.max(stored + Math.max(stack.getAmount(), Integer.MAX_VALUE), Integer.MAX_VALUE);
+			}
+		}
+
+		return (int) stored;
+	}
+
+	@Override
+	public void setOxygenStored(int oxygen) {
+		IGasHandler gasHandler = this.getGasHandler();
+		int tanks = gasHandler.getTanks();
+
+		for (int i = 0; i < tanks; i++) {
+			GasStack stack = gasHandler.getChemicalInTank(i);
+
+			if (stack.getType() == this.getGas()) {
+				gasHandler.setChemicalInTank(i, GasStack.EMPTY);
+			}
+		}
+
+		gasHandler.insertChemical(this.createGasStack(tanks), Action.EXECUTE);
+	}
+
+	@Override
+	public int getMaxOxygenStored() {
+		long capacity = 0;
+		IGasHandler gasHandler = this.getGasHandler();
+		int tanks = gasHandler.getTanks();
+
+		for (int i = 0; i < tanks; i++) {
+			if (gasHandler.isValid(i, this.createGasStack(1))) {
+				capacity = Math.max(capacity + Math.max(gasHandler.getTankCapacity(i), Integer.MAX_VALUE), Integer.MAX_VALUE);
+			}
+		}
+
+		return (int) capacity;
+	}
+
+	public IGasHandler getGasHandler() {
+		return this.gasHandler;
+	}
+
+	public boolean isCanExtract() {
+		return this.canExtract;
+	}
+
+	public boolean isCanReceive() {
+		return this.canReceive;
+	}
+
+}

--- a/src/main/java/net/mrscauthd/boss_tools/compat/mekanism/MekanismCompat.java
+++ b/src/main/java/net/mrscauthd/boss_tools/compat/mekanism/MekanismCompat.java
@@ -1,0 +1,23 @@
+package net.mrscauthd.boss_tools.compat.mekanism;
+
+import net.minecraft.util.ResourceLocation;
+import net.mrscauthd.boss_tools.compat.CompatibleMod;
+
+public class MekanismCompat extends CompatibleMod {
+	public static final String MODID = "mekanism";
+
+	public static ResourceLocation rl(String path) {
+		return new ResourceLocation(MODID, path);
+	}
+
+	@Override
+	public String getModID() {
+		return MODID;
+	}
+
+	@Override
+	protected void onLoad() {
+
+	}
+
+}

--- a/src/main/java/net/mrscauthd/boss_tools/compat/mekanism/MekanismHelper.java
+++ b/src/main/java/net/mrscauthd/boss_tools/compat/mekanism/MekanismHelper.java
@@ -1,0 +1,49 @@
+package net.mrscauthd.boss_tools.compat.mekanism;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import mekanism.api.chemical.gas.IGasHandler;
+import mekanism.common.capabilities.Capabilities;
+import mekanism.common.integration.lookingat.theoneprobe.TOPChemicalElement;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.capabilities.Capability;
+import net.mrscauthd.boss_tools.capability.IOxygenStorage;
+
+public class MekanismHelper {
+	public static Capability<IGasHandler> getGasHandlerCapability() {
+		return Capabilities.GAS_HANDLER_CAPABILITY;
+	}
+
+	public static IGasHandler getItemStackGasHandler(ItemStack itemStack) {
+		if (itemStack.isEmpty()) {
+			return null;
+		}
+
+		return itemStack.getCapability(getGasHandlerCapability()).orElse(null);
+	}
+
+	public static IOxygenStorage getItemStackOxygenAdapter(ItemStack itemStack) {
+		IGasHandler gasHandler = getItemStackGasHandler(itemStack);
+
+		if (gasHandler != null) {
+			return new GasHandlerOxygenAdapter(gasHandler, true, false);
+		} else {
+			return null;
+		}
+	}
+
+	public static List<TOPChemicalElement> createGasGaugeDataElement(IGasHandler gasHandler) {
+		List<TOPChemicalElement> list = new ArrayList<>();
+
+		if (gasHandler != null) {
+			int tanks = gasHandler.getTanks();
+
+			for (int i = 0; i < tanks; i++) {
+				list.add(new TOPChemicalElement.GasElement(gasHandler.getChemicalInTank(i), gasHandler.getTankCapacity(i)));
+			}
+		}
+
+		return list;
+	}
+}

--- a/src/main/java/net/mrscauthd/boss_tools/compat/mekanism/OxygenStorageGasAdapter.java
+++ b/src/main/java/net/mrscauthd/boss_tools/compat/mekanism/OxygenStorageGasAdapter.java
@@ -1,0 +1,94 @@
+package net.mrscauthd.boss_tools.compat.mekanism;
+
+import mekanism.api.Action;
+import mekanism.api.chemical.gas.Gas;
+import mekanism.api.chemical.gas.GasStack;
+import mekanism.api.chemical.gas.IGasHandler;
+import mekanism.common.registries.MekanismGases;
+import net.mrscauthd.boss_tools.capability.IOxygenStorage;
+
+public class OxygenStorageGasAdapter implements IGasHandler {
+
+	private IOxygenStorage oxygenStorage;
+	private boolean canExtract;
+	private boolean canInsert;
+
+	public OxygenStorageGasAdapter(IOxygenStorage oxygenStorage) {
+		this(oxygenStorage, true, true);
+	}
+
+	public OxygenStorageGasAdapter(IOxygenStorage oxygenStorage, boolean canExtract, boolean canInsert) {
+		this.oxygenStorage = oxygenStorage;
+		this.canExtract = canExtract;
+		this.canInsert = canInsert;
+	}
+
+	public Gas getGas() {
+		return MekanismGases.OXYGEN.get();
+	}
+
+	protected GasStack createGasStack(long amount) {
+		return new GasStack(this.getGas(), amount);
+	}
+
+	@Override
+	public GasStack extractChemical(int var1, long var2, Action var4) {
+		if (this.isCanExtract()) {
+			int extractOxygen = this.getOxygenStorage().extractOxygen((int) var2, var4.simulate());
+			return this.createGasStack(extractOxygen);
+		} else {
+			return GasStack.EMPTY;
+		}
+	}
+
+	@Override
+	public GasStack getChemicalInTank(int var1) {
+		return this.createGasStack(this.getOxygenStorage().getOxygenStored());
+	}
+
+	@Override
+	public long getTankCapacity(int var1) {
+		return this.getOxygenStorage().getMaxOxygenStored();
+	}
+
+	@Override
+	public int getTanks() {
+		return 1;
+	}
+
+	@Override
+	public GasStack insertChemical(int var1, GasStack var2, Action var3) {
+		if (this.isCanInsert() && this.isValid(var1, var2)) {
+			int amount = (int) Math.min(var2.getAmount(), Integer.MAX_VALUE);
+			int receiveOxygen = this.getOxygenStorage().receiveOxygen(amount, var3.simulate());
+			return this.createGasStack(var2.getAmount() - receiveOxygen);
+		} else {
+			return var2;
+		}
+	}
+
+	@Override
+	public void setChemicalInTank(int var1, GasStack var2) {
+		if (this.isCanInsert() && this.isValid(var1, var2)) {
+			this.getOxygenStorage().setOxygenStored((int) var2.getAmount());
+		}
+	}
+
+	@Override
+	public boolean isValid(int var1, GasStack var2) {
+		return var2.getType() == this.getGas();
+	}
+
+	public IOxygenStorage getOxygenStorage() {
+		return this.oxygenStorage;
+	}
+
+	public boolean isCanExtract() {
+		return this.canExtract;
+	}
+
+	public boolean isCanInsert() {
+		return this.canInsert;
+	}
+
+}

--- a/src/main/java/net/mrscauthd/boss_tools/compat/theoneprobe/ProbeInfoProvider.java
+++ b/src/main/java/net/mrscauthd/boss_tools/compat/theoneprobe/ProbeInfoProvider.java
@@ -1,7 +1,9 @@
 package net.mrscauthd.boss_tools.compat.theoneprobe;
 
+import java.util.List;
 import java.util.function.Function;
 
+import mcjty.theoneprobe.api.IElement;
 import mcjty.theoneprobe.api.IProbeHitData;
 import mcjty.theoneprobe.api.IProbeInfo;
 import mcjty.theoneprobe.api.IProbeInfoProvider;
@@ -12,6 +14,8 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import net.mrscauthd.boss_tools.compat.CompatibleManager;
+import net.mrscauthd.boss_tools.compat.mekanism.MekanismHelper;
 import net.mrscauthd.boss_tools.machines.tile.AbstractMachineTileEntity;
 
 public class ProbeInfoProvider implements IProbeInfoProvider, Function<ITheOneProbe, Void> {
@@ -37,6 +41,12 @@ public class ProbeInfoProvider implements IProbeInfoProvider, Function<ITheOnePr
 
 		if (tileEntity instanceof AbstractMachineTileEntity) {
 			AbstractMachineTileEntity machineTileEntity = (AbstractMachineTileEntity) tileEntity;
+			
+			if (CompatibleManager.MEKANISM.isLoaded()) {
+				List<? extends IElement> elements = MekanismHelper.createGasGaugeDataElement(machineTileEntity.getCapability(MekanismHelper.getGasHandlerCapability()).orElse(null));
+				elements.forEach(element -> probeInfo.element(element));
+			}
+
 			machineTileEntity.getGaugeDataList().forEach(g -> probeInfo.element(new GaugeDataElement(g)));
 		}
 	}

--- a/src/main/java/net/mrscauthd/boss_tools/machines/tile/OxygenMakingTileEntity.java
+++ b/src/main/java/net/mrscauthd/boss_tools/machines/tile/OxygenMakingTileEntity.java
@@ -23,6 +23,9 @@ import net.mrscauthd.boss_tools.capability.CapabilityOxygen;
 import net.mrscauthd.boss_tools.capability.IOxygenStorage;
 import net.mrscauthd.boss_tools.capability.IOxygenStorageHolder;
 import net.mrscauthd.boss_tools.capability.OxygenStorage;
+import net.mrscauthd.boss_tools.compat.CompatibleManager;
+import net.mrscauthd.boss_tools.compat.mekanism.MekanismHelper;
+import net.mrscauthd.boss_tools.compat.mekanism.OxygenStorageGasAdapter;
 import net.mrscauthd.boss_tools.crafting.BossToolsRecipeType;
 import net.mrscauthd.boss_tools.crafting.OxygenMakingRecipeAbstract;
 import net.mrscauthd.boss_tools.fluid.FluidUtil2;
@@ -70,7 +73,10 @@ public abstract class OxygenMakingTileEntity extends AbstractMachineTileEntity {
 	@Override
 	public List<GaugeData> getGaugeDataList() {
 		List<GaugeData> list = super.getGaugeDataList();
-		list.add(GaugeDataHelper.getOxygen(this.getOutputTank()));
+
+		if (!CompatibleManager.MEKANISM.isLoaded()) {
+			list.add(GaugeDataHelper.getOxygen(this.getOutputTank()));
+		}
 
 		return list;
 	}
@@ -158,6 +164,17 @@ public abstract class OxygenMakingTileEntity extends AbstractMachineTileEntity {
 	}
 
 	@Override
+	public <T> LazyOptional<T> getCapability(Capability<T> capability, Direction facing) {
+		if (CompatibleManager.MEKANISM.isLoaded()) {
+			if (capability == MekanismHelper.getGasHandlerCapability()) {
+				return LazyOptional.of(() -> new OxygenStorageGasAdapter(this.getOutputTank(), false, true)).cast();
+			}
+		}
+
+		return super.getCapability(capability, facing);
+	}
+
+	@Override
 	protected void getSlotsForFace(Direction direction, List<Integer> slots) {
 		super.getSlotsForFace(direction, slots);
 		slots.add(this.getInputSourceSlot());
@@ -219,7 +236,7 @@ public abstract class OxygenMakingTileEntity extends AbstractMachineTileEntity {
 	protected int getInitialInventorySize() {
 		return super.getInitialInventorySize() + 2;
 	}
-	
+
 	@Override
 	public int getInventoryStackLimit() {
 		return 1;


### PR DESCRIPTION
1. I realize even incomplete compatible is better than not compatible
2. Oxygen using machines and Space suit can receive mekanism oxygen
3. but cant' insert bosstools oxygen to mekanism gas handler (unidirectional)
4. This is temporary will until add value as oxygen exchange ratio to config
5. because oxygen loader and bubble distributor can has different oxygen produce ratio<br>so can't decide standard value