### PR TITLE
declare damage sources, add prevent setfire in venus, mercury

### DIFF
--- a/src/main/java/net/mrscauthd/boss_tools/ModInnet.java
+++ b/src/main/java/net/mrscauthd/boss_tools/ModInnet.java
@@ -11,6 +11,7 @@ import net.minecraft.item.crafting.IRecipeSerializer;
 import net.minecraft.potion.Effect;
 import net.minecraft.potion.EffectType;
 import net.minecraft.tileentity.TileEntityType;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.RegistryKey;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.registry.Registry;
@@ -309,6 +310,10 @@ public class ModInnet {
     public static ConfiguredFeature<?, ?> DELTAS2;
     public static VenusDeltas VENUS_DELTAS;
 
+    //DamgeSources
+    public static final DamageSource DAMAGE_SOURCE_OXYGEN = new DamageSource("oxygen").setDamageBypassesArmor();
+    public static final DamageSource DAMAGE_SOURCE_ACID_RAIN = new DamageSource("venus.acid").setDamageBypassesArmor();
+    
     @SubscribeEvent
     public static void RegistryFeature(RegistryEvent.Register<Feature<?>> feature) {
         MARS_ICE_SPIKE = new MarsIceSpikeFeature(NoFeatureConfig.field_236558_a_);

--- a/src/main/java/net/mrscauthd/boss_tools/events/LivingSetFireInHotPlanetEvent.java
+++ b/src/main/java/net/mrscauthd/boss_tools/events/LivingSetFireInHotPlanetEvent.java
@@ -1,0 +1,17 @@
+package net.mrscauthd.boss_tools.events;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraftforge.event.entity.living.LivingEvent;
+
+public class LivingSetFireInHotPlanetEvent extends LivingEvent {
+
+	public LivingSetFireInHotPlanetEvent(LivingEntity entity) {
+		super(entity);
+	}
+
+	@Override
+	public boolean isCancelable() {
+		return true;
+	}
+
+}

--- a/src/main/java/net/mrscauthd/boss_tools/events/Methodes.java
+++ b/src/main/java/net/mrscauthd/boss_tools/events/Methodes.java
@@ -22,6 +22,7 @@ import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.world.World;
 import net.minecraft.world.gen.Heightmap;
 import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.mrscauthd.boss_tools.ModInnet;
@@ -156,7 +157,7 @@ public class Methodes {
     }
 
     public static void OxygenDamage(LivingEntity entity) {
-        entity.attackEntityFrom(new DamageSource("oxygen").setDamageBypassesArmor(), 1.0F);
+        entity.attackEntityFrom(ModInnet.DAMAGE_SOURCE_OXYGEN, 1.0F);
     }
 
     public static boolean isInRocket(Entity entity) {
@@ -208,7 +209,9 @@ public class Methodes {
 
         if (key == RegistryKey.getOrCreateKey(Registry.WORLD_KEY, planet1) || key == RegistryKey.getOrCreateKey(Registry.WORLD_KEY, planet2)) {
             if (!Methodes.Nethrite_Space_Suit_Check(entity)) {
-                entity.setFire(10);
+            	if (!MinecraftForge.EVENT_BUS.post(new LivingSetFireInHotPlanetEvent(entity))) {
+            		entity.setFire(10);
+            	}
             }
         }
     }
@@ -219,7 +222,7 @@ public class Methodes {
             if (entity.world.getWorldInfo().isRaining() && entity.world.getHeight(Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, (int) Math.floor(entity.getPosX()), (int) Math.floor(entity.getPosZ())) <= Math.floor(entity.getPosY()) + 1) {
                 if (EntityTypeTags.getCollection().getTagByID(new ResourceLocation(("forge:entities/venus_rain").toLowerCase(java.util.Locale.ENGLISH))).contains(entity.getType()) == false) {
 
-                    entity.attackEntityFrom(new DamageSource("venus.acid").setDamageBypassesArmor(), 1);
+                	entity.attackEntityFrom(ModInnet.DAMAGE_SOURCE_ACID_RAIN, 1);
                 }
             }
         }


### PR DESCRIPTION
1. Declare  'damage source' fields usually uses
2. Create event before set fire to living entity in  venus, mercury
(other mods, items, etc. can be prevent set fire)

