### PR TITLE
check GravityType before post gravity event

### DIFF
--- a/src/main/java/net/mrscauthd/boss_tools/events/Gravity.java
+++ b/src/main/java/net/mrscauthd/boss_tools/events/Gravity.java
@@ -9,11 +9,6 @@ import net.mrscauthd.boss_tools.events.forgeevents.LivingGravityEvent;
 
 public class Gravity {
     public static void Gravity(LivingEntity entity, GravityType type, World world) {
-
-        if (MinecraftForge.EVENT_BUS.post(new LivingGravityEvent(entity))) {
-            return;
-        }
-
         double moon = 0.03;
         double mars = 0.04;
         double mercury = 0.03;
@@ -62,18 +57,26 @@ public class Gravity {
     }
 
     public static void gravityMath(GravityType type, LivingEntity entity, double gravity, float fallDistance) {
-        if (type == GravityType.PLAYER && playerGravityCheck((PlayerEntity) entity)) {
+    	if (!checkType(type, entity)) {
+    		return;
+    	}
 
-            entity.setMotion(entity.getMotion().getX(), entity.getMotion().getY() / 0.98 + 0.08 - gravity, entity.getMotion().getZ());
-            fallDamage(entity, fallDistance);
+    	if (MinecraftForge.EVENT_BUS.post(new LivingGravityEvent(entity))) {
+    		return;
+    	}
 
-        } else if (type == GravityType.LIVING && livingGravityCheck(entity)) {
+    	entity.setMotion(entity.getMotion().getX(), entity.getMotion().getY() / 0.98 + 0.08 - gravity, entity.getMotion().getZ());
+    	fallDamage(entity, fallDistance);
+	}
 
-            entity.setMotion(entity.getMotion().getX(), entity.getMotion().getY() / 0.98 + 0.08 - gravity, entity.getMotion().getZ());
-            fallDamage(entity, fallDistance);
+    public static boolean checkType(GravityType type, LivingEntity entity) {
+    	if (type == GravityType.PLAYER && playerGravityCheck((PlayerEntity) entity)) {
+    		return true;
+    	} else if (type == GravityType.LIVING && livingGravityCheck(entity)) {
+    		return true;
+    	}
 
-        }
-
+    	return false;
     }
 
     public static void fallDamage (LivingEntity entity, float fallDistance) {

--- a/src/main/java/net/mrscauthd/boss_tools/mixin/MixinItemGravity.java
+++ b/src/main/java/net/mrscauthd/boss_tools/mixin/MixinItemGravity.java
@@ -16,10 +16,6 @@ public abstract class MixinItemGravity {
     private void tick(CallbackInfo info) {
         ItemEntity w = (ItemEntity) ((Object) this);
 
-        if (MinecraftForge.EVENT_BUS.post(new ItemGravityEvent((ItemEntity) w.getEntity()))) {
-            return;
-        }
-
         if (GravityCheckItem(w)) {
             if (Methodes.isWorld(w.world, new ResourceLocation("boss_tools:moon"))) {
                 itemGravityMath(w,0.05);
@@ -53,6 +49,10 @@ public abstract class MixinItemGravity {
     }
 
     private static void itemGravityMath(ItemEntity entity, double gravity) {
+        if (MinecraftForge.EVENT_BUS.post(new ItemGravityEvent(entity))) {
+            return;
+        }
+
         entity.setMotion(entity.getMotion().getX(), entity.getMotion().getY() / 0.98 + 0.08 - gravity, entity.getMotion().getZ());
     }
 


### PR DESCRIPTION
* Currently, player's gravity event post twice
1. Events.onLivingEntityTick
2. Events.onPlayerTick

LivingGravityEvent can't know GravityType
so i can't cancel event in right time


* Gravity event posted in overworld

i guess not post in minecraft dimensions better
check GravityType before post event
