### PR TITLE
Enhancement generator energy eject

### DIFF
--- a/src/main/java/net/mrscauthd/boss_tools/machines/SolarPanelBlock.java
+++ b/src/main/java/net/mrscauthd/boss_tools/machines/SolarPanelBlock.java
@@ -48,7 +48,7 @@ import net.mrscauthd.boss_tools.machines.tile.GeneratorTileEntity;
 import javax.annotation.Nullable;
 
 public class SolarPanelBlock {
-	public static final int ENERGY_PER_TICK = 4;
+	public static final int ENERGY_PER_TICK = 5;
 
 	public static class CustomBlock extends Block {
 

--- a/src/main/java/net/mrscauthd/boss_tools/machines/tile/GeneratorTileEntity.java
+++ b/src/main/java/net/mrscauthd/boss_tools/machines/tile/GeneratorTileEntity.java
@@ -6,8 +6,6 @@ import java.util.List;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.Direction;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
@@ -65,36 +63,161 @@ public abstract class GeneratorTileEntity extends AbstractMachineTileEntity {
 		return this.createEnergyStorageCommon();
 	}
 
-	protected void ejectEnergy() {
-		for (Direction direction : this.getEjectDirections()) {
-			this.ejectEnergy(direction);
+	public class EjectingTuple {
+		public final IEnergyStorage energyStorage;
+		public int receivable;
+		public int receiving;
+
+		public EjectingTuple(IEnergyStorage energyStorage) {
+			this.energyStorage = energyStorage;
 		}
+
+		public boolean isFull() {
+			return this.receiving >= this.receivable;
+		}
+
 	}
 
-	protected int getAutoEjectingEnergy() {
-		return 1;
-	}
-
-	protected int ejectEnergy(Direction direction) {
+	protected void ejectEnergy() {
 		IEnergyStorage source = this.getGeneratingEnergyStorage();
-		World world = this.getWorld();
-		BlockPos pos = this.getPos();
+		int ejectingEnergy = source.extractEnergy(this.getEjectingExtractEnergy(), true);
+		List<IEnergyStorage> sinks = this.findNearEnergyStorages();
+		List<EjectingTuple> tuples = new ArrayList<>();
 
-		TileEntity tileEntity = world.getTileEntity(pos.offset(direction));
+		for (int i = 0; i < sinks.size(); i++) {
+			IEnergyStorage sink = sinks.get(i);
+			EjectingTuple e = new EjectingTuple(sink);
+			e.receivable = sink.receiveEnergy(ejectingEnergy, true);
+			e.receiving = 0;
+			tuples.add(e);
+		}
 
-		if (tileEntity != null) {
-			LazyOptional<IEnergyStorage> capability = tileEntity.getCapability(CapabilityEnergy.ENERGY, direction.getOpposite());
+		ejectingEnergy = this.calculateBalance(ejectingEnergy, tuples);
+		ejectingEnergy = this.calculateRemained(ejectingEnergy, tuples);
 
-			if (capability != null && capability.isPresent()) {
-				IEnergyStorage sink = capability.resolve().get();
-				int extractEnergy = source.extractEnergy(this.getAutoEjectingEnergy(), true);
-				int receiveEnergy = sink.receiveEnergy(extractEnergy, true);
+		for (EjectingTuple tuple : tuples) {
+			int extracted = source.extractEnergy(tuple.receiving, false);
+			tuple.energyStorage.receiveEnergy(extracted, false);
+		}
 
-				int real = source.extractEnergy(receiveEnergy, false);
-				return sink.receiveEnergy(real, false);
+//		System.out.println(tuples.stream().map(t -> t.receiving).collect(Collectors.toList()).toString() + ", remain=" + ejectingEnergy);
+	}
+
+	/**
+	 * provide remain energy to not full tuples
+	 * @param energy
+	 * @param tuples
+	 * @return
+	 */
+	private int calculateRemained(int energy, List<EjectingTuple> tuples) {
+		int tuplesSize = tuples.size();
+		int fullCount = (int) tuples.stream().filter(EjectingTuple::isFull).count();
+		int remainCount = tuplesSize - fullCount;
+
+		if (remainCount > 0) {
+			int divided = (int) Math.ceil(energy / (double) remainCount);
+
+			for (int i = 0; i < tuplesSize; i++) {
+				EjectingTuple tuple = tuples.get(i);
+
+				if (!tuple.isFull()) {
+					if (energy <= 0) {
+						break;
+					}
+
+					int give = Math.min(divided, energy);
+					tuple.receiving += give;
+					energy -= give;
+					int over = tuple.receiving - tuple.receivable;
+
+					if (over >= 0) {
+						energy += over;
+					}
+				}
 			}
 		}
-		return 0;
+
+		return energy;
+	}
+
+	/**
+	 * calculate possible same receiving until each tuple canRecive
+	 * @param energy
+	 * @param tuples
+	 * @return
+	 */
+	private int calculateBalance(int energy, List<EjectingTuple> tuples) {
+		List<EjectingTuple> orderedReceivables = new ArrayList<EjectingTuple>(tuples);
+		orderedReceivables.sort((o1, o2) -> o1.receivable - o2.receivable);
+
+		for (int i = 0; i < orderedReceivables.size(); i++) {
+			int amount = i == 0 ? orderedReceivables.get(i).receivable : orderedReceivables.get(i).receivable - orderedReceivables.get(i - 1).receivable;
+
+			if (amount <= 0) {
+				continue;
+			}
+
+			int amountSum = 0;
+			int receiveCount = 0;
+
+			for (int j = 0; j < tuples.size(); j++) {
+				if (!tuples.get(j).isFull()) {
+					amountSum += amount;
+					receiveCount++;
+				}
+			}
+
+			if (receiveCount == 0) {
+				break;
+			}
+
+			int give = 0;
+
+			if (amountSum > energy) {
+				give = Math.floorDiv(energy, receiveCount);
+			} else {
+				give = amount;
+			}
+
+			for (int j = 0; j < tuples.size(); j++) {
+				EjectingTuple tuple = tuples.get(j);
+				if (!tuple.isFull()) {
+					tuple.receiving += give;
+					energy -= give;
+					int over = tuple.receiving - tuple.receivable;
+
+					if (over >= 0) {
+						energy += over;
+					}
+				}
+			}
+		}
+
+		return energy;
+	}
+
+	protected List<IEnergyStorage> findNearEnergyStorages() {
+		List<IEnergyStorage> energyStorages = new ArrayList<>();
+
+		for (Direction direction : this.getEjectDirections()) {
+			TileEntity tileEntity = world.getTileEntity(pos.offset(direction));
+
+			if (tileEntity != null) {
+				LazyOptional<IEnergyStorage> capability = tileEntity.getCapability(CapabilityEnergy.ENERGY, direction.getOpposite());
+
+				if (capability != null && capability.isPresent()) {
+					energyStorages.add(capability.resolve().get());
+				}
+
+			}
+
+		}
+
+		return energyStorages;
+	}
+
+	protected int getEjectingExtractEnergy() {
+		return this.getMaxGeneration();
 	}
 
 	protected List<Direction> getEjectDirections() {


### PR DESCRIPTION
1. Change SolarPanel's energy produce to 5 FE/t
2. Generator (Coal, SolarPanel) 's energy eject amount be related MaxGeneration
3. when generator (Coal, SolarPanel) eject energy to tile entity, eject amount is divide by connection count
4. and if some direction's tile entity is full, more eject to instead other directions
may require more test

![image](https://user-images.githubusercontent.com/44163945/140644052-4a889209-b46f-4716-908d-c65c113430c2.png)

![image](https://user-images.githubusercontent.com/44163945/140643973-6f71b435-03ff-4d90-b6b2-cd6cc98441aa.png)

![image](https://user-images.githubusercontent.com/44163945/140644061-36d55351-355e-4a87-9e1a-590004b42236.png)

![image](https://user-images.githubusercontent.com/44163945/140644047-56439aca-31ae-42bd-aded-4a5e6e8f32c2.png)

![image](https://user-images.githubusercontent.com/44163945/140643872-ed9d4d0d-4ec0-468f-932a-a55204ac0f88.png)

![image](https://user-images.githubusercontent.com/44163945/140643894-313b3610-200d-4c49-bdac-9a0da9b314cd.png)
