### PR TITLE
Moon Glowstone Ore recipe, forge/cheese tag

### DIFF
--- a/src/main/resources/data/boss_tools/recipes/moon_glowstone_ore.json
+++ b/src/main/resources/data/boss_tools/recipes/moon_glowstone_ore.json
@@ -1,0 +1,21 @@
+{
+  "group": "boss_tools",
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " D ",
+    "DSD",
+    " D "
+  ],
+  "key": {
+    "D": {
+      "item": "minecraft:glowstone_dust"
+    },
+    "S": {
+      "item": "boss_tools:moon_sand"
+    }
+  },
+  "result": {
+    "item": "boss_tools:moon_glowstone_ore",
+    "count": 1
+  }
+}

--- a/src/main/resources/data/forge/tags/items/cheese/cheese.json
+++ b/src/main/resources/data/forge/tags/items/cheese/cheese.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "boss_tools:chesse"
+  ]
+}


### PR DESCRIPTION
1. Add moon glowstone ore crafting recipe
    that blocks so similar with minecraft:glowstone
    so, i idea to add recipe
![image](https://user-images.githubusercontent.com/44163945/143022423-68394589-1d3c-4f2e-9068-fab0228a402a.png)

2. Add forge/cheese tag to Chesse
    it can be compatible with pam's harvestcraft 2 - food
    like below
![image](https://user-images.githubusercontent.com/44163945/143022438-dc637a09-04d0-41d1-8f04-704bc2f9718c.png)
