### PR TITLE
enhancment wheel recipe, add ice shard ore recipe

### DIFF
--- a/src/main/resources/data/boss_tools/recipes/mars_ice_shard_ore.json
+++ b/src/main/resources/data/boss_tools/recipes/mars_ice_shard_ore.json
@@ -1,0 +1,21 @@
+{
+  "group": "boss_tools",
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    " D ",
+    "DSD",
+    " D "
+  ],
+  "key": {
+    "D": {
+      "item": "boss_tools:ice_shard"
+    },
+    "S": {
+      "item": "boss_tools:mars_sand"
+    }
+  },
+  "result": {
+    "item": "boss_tools:mars_ice_shard_ore",
+    "count": 1
+  }
+}

--- a/src/main/resources/data/boss_tools/recipes/wheel.json
+++ b/src/main/resources/data/boss_tools/recipes/wheel.json
@@ -11,25 +11,25 @@
       "item": "minecraft:black_dye"
     },
     "1": {
-      "item": "minecraft:slime_ball"
+      "tag": "forge:slimeballs"
     },
     "2": {
       "item": "minecraft:black_dye"
     },
     "3": {
-      "item": "minecraft:slime_ball"
+      "tag": "forge:slimeballs"
     },
     "4": {
       "tag": "forge:ingots/steel"
     },
     "5": {
-      "item": "minecraft:slime_ball"
+      "tag": "forge:slimeballs"
     },
     "6": {
       "item": "minecraft:black_dye"
     },
     "7": {
-      "item": "minecraft:slime_ball"
+      "tag": "forge:slimeballs"
     },
     "8": {
       "item": "minecraft:black_dye"


### PR DESCRIPTION
1. for same cause with moon glowstone ore

![image](https://user-images.githubusercontent.com/44163945/143600602-1ecd3021-e1af-4c42-a288-003e7a7bca3c.png)

2. can use other type slimeballs to crafting wheel
![Animation](https://user-images.githubusercontent.com/44163945/143600648-31eb6bd6-05bc-41e8-81b8-aad5f4b20b19.gif)

3. has you missing coal lantern recipe?