### PR TITLE
fix spacesuit's oxygen for extract using each player's timer

### DIFF
--- a/src/main/java/net/mrscauthd/boss_tools/armor/NetheriteSpaceSuit.java
+++ b/src/main/java/net/mrscauthd/boss_tools/armor/NetheriteSpaceSuit.java
@@ -1,10 +1,8 @@
 package net.mrscauthd.boss_tools.armor;
 
 import net.mrscauthd.boss_tools.BossToolsMod;
-import net.mrscauthd.boss_tools.ModInnet;
 import net.mrscauthd.boss_tools.armormaterial.SpaceSuitNetheriteArmorMaterial;
 import net.mrscauthd.boss_tools.entity.renderer.spacesuit.SpaceSuitModel;
-import net.mrscauthd.boss_tools.events.Config;
 import net.mrscauthd.boss_tools.events.Methodes;
 import net.mrscauthd.boss_tools.capability.IOxygenStorage;
 import net.mrscauthd.boss_tools.capability.OxygenUtil;
@@ -32,8 +30,6 @@ import net.minecraft.client.renderer.entity.model.BipedModel;
 import java.util.List;
 
 public class NetheriteSpaceSuit {
-
-	public static double OXYGEN_TIMER = 0;
 
 	public static ArmorItem NETHERITE_OXYGEN_MASK = new ArmorItem(SpaceSuitNetheriteArmorMaterial.ARMOR_MATERIAL, EquipmentSlotType.HEAD, new Item.Properties().group(BossToolsItemGroups.tab_normal).isImmuneToFire()) {
 		@Override
@@ -86,18 +82,7 @@ public class NetheriteSpaceSuit {
 
 		@Override
 		public void onArmorTick(ItemStack itemstack, World world, PlayerEntity player) {
-			if (!player.abilities.isCreativeMode && !player.isSpectator() && Methodes.spaceSuitCheckBoth(player) && Config.PlayerOxygenSystem) {
-				IOxygenStorage oxygenStorage = OxygenUtil.getItemStackOxygenStorage(itemstack);
-
-				OXYGEN_TIMER = OXYGEN_TIMER + 1;
-
-				if (oxygenStorage.getOxygenStored() > 0 && OXYGEN_TIMER > 3 && !player.isPotionActive(ModInnet.OXYGEN_EFFECT.get())) {
-					oxygenStorage.extractOxygen(1, false);
-					OXYGEN_TIMER = 0;
-				}
-
-			}
-
+			Methodes.extractArmorOxygenUsingTimer(itemstack, player);
 		}
 	};
 

--- a/src/main/java/net/mrscauthd/boss_tools/armor/SpaceSuit.java
+++ b/src/main/java/net/mrscauthd/boss_tools/armor/SpaceSuit.java
@@ -1,10 +1,8 @@
 package net.mrscauthd.boss_tools.armor;
 
 import net.mrscauthd.boss_tools.BossToolsMod;
-import net.mrscauthd.boss_tools.ModInnet;
 import net.mrscauthd.boss_tools.armormaterial.SpaceSuitArmorMaterial;
 import net.mrscauthd.boss_tools.entity.renderer.spacesuit.SpaceSuitModel;
-import net.mrscauthd.boss_tools.events.Config;
 import net.mrscauthd.boss_tools.events.Methodes;
 import net.mrscauthd.boss_tools.capability.IOxygenStorage;
 import net.mrscauthd.boss_tools.capability.OxygenUtil;
@@ -32,8 +30,6 @@ import net.minecraft.client.renderer.entity.model.BipedModel;
 import java.util.List;
 
 public class SpaceSuit {
-
-	public static double OXYGEN_TIMER = 0;
 
 	public static ArmorItem OXYGEN_MASK = new ArmorItem(SpaceSuitArmorMaterial.ArmorMaterial, EquipmentSlotType.HEAD, new Item.Properties().group(BossToolsItemGroups.tab_normal)) {
 		@Override
@@ -86,19 +82,9 @@ public class SpaceSuit {
 
 		@Override
 		public void onArmorTick(ItemStack itemstack, World world, PlayerEntity player) {
-			if (!player.abilities.isCreativeMode && !player.isSpectator() && Methodes.spaceSuitCheckBoth(player) && Config.PlayerOxygenSystem) {
-				IOxygenStorage oxygenStorage = OxygenUtil.getItemStackOxygenStorage(itemstack);
-
-				OXYGEN_TIMER = OXYGEN_TIMER + 1;
-
-				if (oxygenStorage.getOxygenStored() > 0 && OXYGEN_TIMER > 3 && !player.isPotionActive(ModInnet.OXYGEN_EFFECT.get())) {
-					oxygenStorage.extractOxygen(1, false);
-					OXYGEN_TIMER = 0;
-				}
-
-			}
-
+			Methodes.extractArmorOxygenUsingTimer(itemstack, player);
 		}
+
 	};
 
 	public static ArmorItem SPACE_PANTS = new ArmorItem(SpaceSuitArmorMaterial.ArmorMaterial, EquipmentSlotType.LEGS, new Item.Properties().group(BossToolsItemGroups.tab_normal)) {

--- a/src/main/java/net/mrscauthd/boss_tools/events/Methodes.java
+++ b/src/main/java/net/mrscauthd/boss_tools/events/Methodes.java
@@ -16,6 +16,7 @@ import net.minecraft.inventory.container.INamedContainerProvider;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.network.play.server.SChangeGameStatePacket;
 import net.minecraft.network.play.server.SPlayEntityEffectPacket;
@@ -38,6 +39,8 @@ import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.mrscauthd.boss_tools.BossToolsMod;
 import net.mrscauthd.boss_tools.ModInnet;
+import net.mrscauthd.boss_tools.capability.IOxygenStorage;
+import net.mrscauthd.boss_tools.capability.OxygenUtil;
 import net.mrscauthd.boss_tools.entity.*;
 import net.mrscauthd.boss_tools.events.forgeevents.LivingSetFireInHotPlanetEvent;
 import net.mrscauthd.boss_tools.events.forgeevents.LivingSetVenusRainEvent;
@@ -444,4 +447,22 @@ public class Methodes {
             Methodes.worldTeleport(player, planet, 450);
         }
     }
+
+	public static void extractArmorOxygenUsingTimer(ItemStack itemstack, PlayerEntity player) {
+		if (!player.abilities.isCreativeMode && !player.isSpectator() && Methodes.spaceSuitCheckBoth(player) && Config.PlayerOxygenSystem) {
+			IOxygenStorage oxygenStorage = OxygenUtil.getItemStackOxygenStorage(itemstack);
+
+			CompoundNBT persistentData = player.getPersistentData();
+			String key = BossToolsMod.ModId + ":oxygen_timer";
+			int oxygenTimer = persistentData.getInt(key);
+			oxygenTimer++;
+
+			if (oxygenStorage.getOxygenStored() > 0 && oxygenTimer > 3 && !player.isPotionActive(ModInnet.OXYGEN_EFFECT.get())) {
+				oxygenStorage.extractOxygen(1, false);
+				oxygenTimer = 0;
+			}
+
+			persistentData.putInt(key, oxygenTimer);
+		}
+	}
 }


### PR DESCRIPTION
1. previous code's OXYGEN_TIMER is spacesuit class's static field
2. but Item#onArmorTick method be called from each player on tick
3. it did OXYGEN_TIMER has faster operation if other player equip spacesuit too
4. so, i remove static field OXYGEN_TIMER and instead each player's persistent data
