### PR TITLE
Coal lantern recipe, jaopca compat complete

### DIFF
--- a/src/main/resources/data/boss_tools/recipes/coal_lantern.json
+++ b/src/main/resources/data/boss_tools/recipes/coal_lantern.json
@@ -1,0 +1,21 @@
+{
+  "group": "boss_tools",
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "nnn",
+    "ntn",
+    "nnn"
+  ],
+  "key": {
+    "n": {
+      "tag": "forge:nuggets/iron"
+    },
+    "t": {
+      "item": "boss_tools:coal_torch"
+    }
+  },
+  "result": {
+    "item": "boss_tools:coal_lantern",
+    "count": 1
+  }
+}

--- a/src/main/resources/data/boss_tools/recipes/smeltery/casting/metal/iron/coal_lantern.json
+++ b/src/main/resources/data/boss_tools/recipes/smeltery/casting/metal/iron/coal_lantern.json
@@ -1,0 +1,13 @@
+{
+  "type": "tconstruct:casting_table",
+  "cast": {
+    "item": "boss_tools:coal_torch"
+  },
+  "cast_consumed": true,
+  "fluid": {
+    "tag": "forge:molten_iron",
+    "amount": 128
+  },
+  "result": "boss_tools:coal_lantern",
+  "cooling_time": 57
+}

--- a/src/main/resources/data/forge/tags/fluids/molten_desh.json
+++ b/src/main/resources/data/forge/tags/fluids/molten_desh.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#boss_tools:molten_desh"
+  ]
+}

--- a/src/main/resources/data/forge/tags/fluids/molten_silicon.json
+++ b/src/main/resources/data/forge/tags/fluids/molten_silicon.json
@@ -1,7 +1,6 @@
 {
   "replace": false,
   "values": [
-    "#boss_tools:molten_desh",
     "#boss_tools:molten_silicon"
   ]
 }

--- a/src/main/resources/data/tconstruct/tags/fluids/metal_like.json
+++ b/src/main/resources/data/tconstruct/tags/fluids/metal_like.json
@@ -1,7 +1,7 @@
 {
   "replace": false,
   "values": [
-    "#boss_tools:molten_desh",
-    "#boss_tools:molten_silicon"
+    "#forge:molten_desh",
+    "#forge:molten_silicon"
   ]
 }


### PR DESCRIPTION
1. Add coal lantern recipe (i think you forgot this, if is not, sry)
reference minecraft:lantern, soullantern
![image](https://user-images.githubusercontent.com/44163945/143881780-56e651e6-ea3a-4d45-bc22-935957152cdb.png)
tinker compat recipe
![image](https://user-images.githubusercontent.com/44163945/143881797-bda2ce51-251c-4c86-8991-f5a6e99ffde0.png)

2. Fix molten fluid tags for jaopca compat complete
it prevent jaopca register duplicated molten fluid
