### PR TITLE
Render oxygen percent text below oxygen overlay

### DIFF
--- a/src/main/java/net/mrscauthd/boss_tools/events/OverlayEvents.java
+++ b/src/main/java/net/mrscauthd/boss_tools/events/OverlayEvents.java
@@ -11,6 +11,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.IFormattableTextComponent;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
@@ -21,7 +22,10 @@ import net.minecraftforge.fml.common.Mod;
 import net.mrscauthd.boss_tools.BossToolsMod;
 import net.mrscauthd.boss_tools.ModInnet;
 import net.mrscauthd.boss_tools.capability.CapabilityOxygen;
+import net.mrscauthd.boss_tools.capability.IOxygenStorage;
 import net.mrscauthd.boss_tools.entity.*;
+import net.mrscauthd.boss_tools.gauge.GaugeTextHelper;
+import net.mrscauthd.boss_tools.gauge.GaugeValueHelper;
 import net.mrscauthd.boss_tools.gui.helper.GuiHelper;
 
 @Mod.EventBusSubscriber(modid = BossToolsMod.ModId, value = Dist.CLIENT)
@@ -50,7 +54,8 @@ public class OverlayEvents {
         }
     }
 
-    @SubscribeEvent(priority = EventPriority.HIGH)
+    @SuppressWarnings("resource")
+	@SubscribeEvent(priority = EventPriority.HIGH)
     public static void Overlay(RenderGameOverlayEvent event) {
 
         //Disable Food Overlay
@@ -180,12 +185,20 @@ public class OverlayEvents {
             Item chestItem = chest.getItem();
 
             if (chestItem == ModInnet.SPACE_SUIT.get() || chestItem == ModInnet.NETHERITE_SPACE_SUIT.get()) {
-                double oxygenStoredRatio = chest.getCapability(CapabilityOxygen.OXYGEN).map(s -> s.getOxygenStoredRatio()).orElse(0.0D);
+                IOxygenStorage oxygenStorage = chest.getCapability(CapabilityOxygen.OXYGEN).orElse(null);
+                double oxygenStoredRatio = oxygenStorage != null ? oxygenStorage.getOxygenStoredRatio() : 0.0D;
                 ResourceLocation empty = new ResourceLocation(BossToolsMod.ModId, "textures/overlay/oxygentankcheck_empty.png");
                 ResourceLocation full = new ResourceLocation(BossToolsMod.ModId, "textures/overlay/oxygentankcheck_full.png");
-                double scale = event.getWindow().getScaledWidth() / 1280.0D;
-                GuiHelper.drawVerticalReverse(event.getMatrixStack(), 5, 5, (int) (124 * scale), (int) (104 * scale), empty, oxygenStoredRatio);
-                GuiHelper.drawVertical(event.getMatrixStack(), 5, 5, (int) (124 * scale), (int) (104 * scale), full, oxygenStoredRatio);
+                int x = 5;
+                int y = 5;
+                int width = 62;
+                int height = 52;
+                GuiHelper.drawVerticalReverse(event.getMatrixStack(), x, y, width, height, empty, oxygenStoredRatio);
+                GuiHelper.drawVertical(event.getMatrixStack(), x, y, width, height, full, oxygenStoredRatio);
+                
+                IFormattableTextComponent text = GaugeTextHelper.getPercentText(GaugeValueHelper.getOxygen(oxygenStorage)).build();
+                int textWidth = Minecraft.getInstance().fontRenderer.getStringPropertyWidth(text);
+                Minecraft.getInstance().fontRenderer.func_243246_a(event.getMatrixStack(), text, (x + (width - textWidth) / 2), y + height + 3, 0xFFFFFF);
             }
 
             RenderSystem.depthMask(true);


### PR DESCRIPTION
1. Fix oxygen tank size
2. Render oxygen percent below oxygen overlay

![image](https://user-images.githubusercontent.com/44163945/144606172-8cf61ca3-ab1b-4b2f-8cb4-b17863451229.png)
![image](https://user-images.githubusercontent.com/44163945/144606177-0075d91c-2375-4922-a05c-7f7cea90b7c0.png)
