### PR TITLE
Fix crash when latest tinkers

### DIFF
--- a/src/main/java/net/mrscauthd/boss_tools/compat/tinkers/TinkersBossToolsFluids.java
+++ b/src/main/java/net/mrscauthd/boss_tools/compat/tinkers/TinkersBossToolsFluids.java
@@ -6,12 +6,12 @@ import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
 import net.mrscauthd.boss_tools.BossToolsMod;
 import slimeknights.mantle.registration.ModelFluidAttributes;
+import slimeknights.mantle.registration.deferred.FluidDeferredRegister;
 import slimeknights.mantle.registration.object.FluidObject;
-import slimeknights.tconstruct.common.registration.FluidDeferredRegisterExtension;
 
 public class TinkersBossToolsFluids
 {
-	protected static final FluidDeferredRegisterExtension FLUIDS = new FluidDeferredRegisterExtension(BossToolsMod.ModId);
+	protected static final FluidDeferredRegister FLUIDS = new FluidDeferredRegister(BossToolsMod.ModId);
 	public static final FluidObject<ForgeFlowingFluid> moltenDesh = FLUIDS.register("molten_desh", hotBuilder().temperature(800), Material.LAVA, 12);
 	public static final FluidObject<ForgeFlowingFluid> moltenSilicon = FLUIDS.register("molten_silicon", hotBuilder().temperature(800), Material.LAVA, 12);
 


### PR DESCRIPTION
sry
idk tinkers remove that api
https://discord.com/channels/698598471896268931/723969509819416586/917454581687025765

now it will compat past, recent tinkers

i test with bellows
1. TConstruct-1.16.5-3.1.3.271
1. TConstruct-1.16.5-3.3.0.308